### PR TITLE
Add 'Asset' type to routes file

### DIFF
--- a/server/conf/routes
+++ b/server/conf/routes
@@ -7,4 +7,4 @@ GET     /                           controllers.Application.index
 
 # Prefix must match `play.assets.urlPrefix`
 GET     /assets/*file           controllers.Assets.at(file)
-GET     /versionedAssets/*file  controllers.Assets.versioned(file: Asset)
+GET     /versionedAssets/*file  controllers.Assets.versioned(path="/public", file: Asset)

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -7,4 +7,4 @@ GET     /                           controllers.Application.index
 
 # Prefix must match `play.assets.urlPrefix`
 GET     /assets/*file           controllers.Assets.at(file)
-GET     /versionedAssets/*file  controllers.Assets.versioned(file)
+GET     /versionedAssets/*file  controllers.Assets.versioned(file: Asset)


### PR DESCRIPTION
If you don't put this type annotation into your routes file, you will not get the fingerprinted asset.